### PR TITLE
fix: close the server after in-flight requests complete

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "delay": "^5.0.0",
+    "p-wait-for": "^3.2.0",
     "roarr": "^4.0.10",
     "type-fest": "^0.20.2"
   },


### PR DESCRIPTION
Currently, if there are any requests in flight when
`terminator.terminate` is called, `terminate` will wait for
`gracefulTerminationTimeout` milliseconds, even if all in-flight
requests complete before that timeout.

This updates the termination logic in `createInternalHttpTerminator` to
close the server as soon as there are no requests in flight; for
example, if the timeout is set to 15000ms but all in-flight requests
are complete after 1000ms, `terminate` will return after ~1000ms.

Fixes #16.